### PR TITLE
5 escaping single quotes in template source 

### DIFF
--- a/STTemplate-Tests/STTemplateTest.class.st
+++ b/STTemplate-Tests/STTemplateTest.class.st
@@ -601,10 +601,16 @@ STTemplateTest >> testNestedDisplayValueFromCustomAttribute [
 { #category : #tests }
 STTemplateTest >> testPartialWithSingleQuote [
 
-	| template |
-	template := '<p>That''s it</p>' asSTTemplate.
+	| template partials |
+	partials := { (#withStringToEscapeQuote
+	             -> '<p>That''s also it!</p>' asSTTemplate) }
+		            asDictionary.
+	template := '<div><p>That''s it and</p><st STT yield: #withStringToEscapeQuote ></div>'
+		            asSTTemplate.
 
-	self assert: template render equals: '<p>That''s it</p>'
+	self
+		assert: (template renderOn: nil partials: partials)
+		equals: '<div><p>That''s it and</p><p>That''s also it!</p></div>'
 ]
 
 { #category : #tests }
@@ -689,7 +695,7 @@ STTemplateTest >> testRenderComposedSnippetWithNamedYield [
 { #category : #tests }
 STTemplateTest >> testRenderComposedSnippetWithoutContext [
 
-	| model job1 job2 partials template result rendered |
+	| model job1 job2 partials template |
 	model := STTDummyJobModel new.
 	job1 := STTDummyJobModel new
 		        description: 'Job 1';
@@ -720,8 +726,7 @@ STTemplateTest >> testRenderComposedSnippetWithoutContext [
 </ul>
 ' asSTTemplate.
 
-template.
-
+	template
 ]
 
 { #category : #tests }

--- a/STTemplate-Tests/STTemplateTest.class.st
+++ b/STTemplate-Tests/STTemplateTest.class.st
@@ -890,6 +890,15 @@ out nextPutAll: ''
 ]
 
 { #category : #tests }
+STTemplateTest >> testTemplateWithSingleQuote [
+
+	| template |
+	template := '<p>That''s it</p>' asSTTemplate.
+
+	self assert: template render equals: '<p>That''s it</p>'
+]
+
+{ #category : #tests }
 STTemplateTest >> testValueFromTempVar [
 
 	| source |

--- a/STTemplate-Tests/STTemplateTest.class.st
+++ b/STTemplate-Tests/STTemplateTest.class.st
@@ -599,6 +599,15 @@ STTemplateTest >> testNestedDisplayValueFromCustomAttribute [
 ]
 
 { #category : #tests }
+STTemplateTest >> testPartialWithSingleQuote [
+
+	| template |
+	template := '<p>That''s it</p>' asSTTemplate.
+
+	self assert: template render equals: '<p>That''s it</p>'
+]
+
+{ #category : #tests }
 STTemplateTest >> testRenderComposedRenderedWithoutContext [
 
 	| templateContext job1 job2 partials template result |

--- a/STTemplate/STTemplate.class.st
+++ b/STTemplate/STTemplate.class.st
@@ -379,6 +379,12 @@ STTemplate >> nextSmalltalkExpressionIn: src using: closingTag [
 ]
 
 { #category : #actions }
+STTemplate >> render [
+
+	^ self renderOn: nil
+]
+
+{ #category : #actions }
 STTemplate >> renderNamedYieldsFrom: smalltalkExpression on: rendered [
 
 	| partialRenderingSnippet |

--- a/STTemplate/STTemplate.class.st
+++ b/STTemplate/STTemplate.class.st
@@ -448,9 +448,8 @@ STTemplate >> renderSourceFor: src on: rendered openingTag: openingTag closingTa
 
 	"Answers the Smalltalk source code for the method that, once compiled and 
 	evaluated on a template context, returns its rendering."
-	
+
 	| prelude smalltalkExpression forDisplaying renderedSource displayResult |
-	
 	forDisplaying := false.
 	prelude := src upToAll: openingTag.
 	prelude ifNotEmpty: [ 
@@ -459,7 +458,7 @@ STTemplate >> renderSourceFor: src on: rendered openingTag: openingTag closingTa
 		rendered
 			nextPutAll: 'out nextPutAll: ';
 			nextPut: $';
-			nextPutAll: prelude;
+			nextPutAll: prelude asSingleQuoteEscaped;
 			nextPut: $'.
 		self addLineTerminationFor: '' on: rendered ].
 	src atEnd ifFalse: [ "There is source to process still so, let's see.

--- a/STTemplate/String.extension.st
+++ b/STTemplate/String.extension.st
@@ -9,6 +9,22 @@ String >> asSTTemplate [
 ]
 
 { #category : #'*STTemplate' }
+String >> asSingleQuoteEscaped [
+
+	"Answer a copy of the receiver that has an extra 
+	single quote for every one found in the origial."
+
+	| current |
+	^ self class streamContents: [ :out | 
+		  self readStreamDo: [ :in | 
+			  [ in atEnd ] whileFalse: [ 
+				  current := in next.
+				  current = $'
+					  ifTrue: [ out nextPutAll: '''''' ]
+					  ifFalse: [ out nextPut: current ] ] ] ]
+]
+
+{ #category : #'*STTemplate' }
 String >> sttRenderOn: anObject [
 
 	"Answers the result of rendering an `STTemplate`


### PR DESCRIPTION
Added `asSingleQuoteEscaped` as a `String` extension so we can use it to concatenate the template source with the single quotes escaped as Smalltalk likes it. 

For coverage I've added:
- testPartialWithSingleQuote and
- testTemplateWithSingleQuote
