### PR TITLE
API adjustment for the STT yielding class to improve friendliness with Ride

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        smalltalk: [ Pharo64-10 ]
+        smalltalk: [ Pharo64-11 ]
     name: ${{ matrix.smalltalk }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Unit Tests
 
-on: [push,pull_request,workflow_dispatch]
+on: [push]
 
 jobs:
    unit-tests:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+Jan 25, 2024
+===================================
+- STT has new deprecated methods in favor of methods that are friendlier to Ride-based applications.
+- `STT yield: aNamedPartialToYield` is now `STT yieldUsing: aNamedPartialToYield`.
+- `STT yield: aNamedPartialToYield on: aContext` is now `STT yield: aContext using: aNamedPartialToYield`.
+
 Jan 23, 2024
 ===================================
 - Added smalltalkCI

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+Feb 17, 2024
+===================================
+- Using by default the same convetion seen in Ruby on Rails.
+
 Jan 23, 2024
 ===================================
 - Added smalltalkCI

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+Feb 17, 2024
+===================================
+- Using by default the same convention seen in Ruby on Rails for opening and closing tags `<% 40+2 %>` and `<%= 40+2 %>` .
+
 Jan 25, 2024
 ===================================
 - STT has new deprecated methods in favor of methods that are friendlier to Ride-based applications.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ spec baseline: 'STTemplate' with: [ spec repository: 'github://sebastianconcept/
 
 `STTemplate` is a Smalltalk template class.
 
-It can run Smalltalk code found between the opening (`<st`) and closing (`>`) tags when present in the content.
+It can run Smalltalk code found between the opening (`<%`) and closing (`%>`) tags when present in the content.
 
 There are two ways to have Smalltalk running from `STTemplate` instances:
 
@@ -60,7 +60,7 @@ There are two ways to have Smalltalk running from `STTemplate` instances:
 Analogous to a `printIt`
 
 ```smalltalk
-'<p><st= ''Hello '', self ></p>' sttRenderOn: 'STT'.
+'<p><%= ''Hello '', self %></p>' sttRenderOn: 'STT'.
 "'<p>Hello STT</p>'"
 ```
 
@@ -69,10 +69,10 @@ Analogous to a `printIt`
 Analogous to a `doIt`
 
 ```smalltalk
-'<p>Hello STT<st 40+2 ></p>' sttRenderOn: 'STT'.
+'<p>Hello STT<% 40+2 %></p>' sttRenderOn: 'STT'.
 "'<p>Hello STT</p>'"
 
-'<p>Hello STT<st self crShow: ''Greetings from an STT closure!'' ></p>' sttRenderOn: Transcript.
+'<p>Hello STT<% self crShow: ''Greetings from an STT closure!'' %></p>' sttRenderOn: Transcript.
 "'<p>Hello STT</p>'"
 
 "And in the Transcript you'll see:"
@@ -85,7 +85,7 @@ Analogous to a `doIt`
 ```smalltalk
 "Displays the 42 as content of the span element:"
 
-'<p>The Answer: <span><st= 42></span></p>' sttRenderOn: nil.
+'<p>The Answer: <span><%= 42%></span></p>' sttRenderOn: nil.
 "'<p>The Answer: <span>42</span></p>'"
 ```
 
@@ -93,7 +93,7 @@ Analogous to a `doIt`
 "Displays the 42 as content of the span element because
 adds 2 to the context sent with `sttRenderOn: 40`"
 
-'<p>The Answer: <span><st= self + 2></span></p>' sttRenderOn: 40.
+'<p>The Answer: <span><%= self + 2%></span></p>' sttRenderOn: 40.
 "'<p>The Answer: <span>42</span></p>'"
 ```
 
@@ -102,7 +102,7 @@ adds 2 to the context sent with `sttRenderOn: 40`"
 so it displays `Answer: ` coming from `self key capitalized, ': '`
 and then `42` coming from displaying `self value + 2`"
 
-'<p>The <span><st= self key capitalized, '': ''></span><span><st= self value + 2></span></p>' sttRenderOn: (#answer -> 40).
+'<p>The <span><%= self key capitalized, '': ''%></span><span><%= self value + 2%></span></p>' sttRenderOn: (#answer -> 40).
 "'<p>The <span>Answer: </span><span>42</span></p>'"
 ```
 
@@ -111,7 +111,7 @@ and then `42` coming from displaying `self value + 2`"
 In each iteration, it creates another Smalltalk closure that has access
 to self as expected and uses that to display its content:"
 
-'<st 1 to: 3 do: [ :i | ><p>The Answer is <span><st= self value + 2>!</span></p><st ] >' sttRenderOn: (#answer -> 40).
+'<% 1 to: 3 do: [ :i | %><p>The Answer is <span><%= self value + 2%>!</span></p><% ] >' sttRenderOn: (#answer -> 40).
 "'<p>The Answer is <span>42!</span></p><p>The Answer is <span>42!</span></p><p>The Answer is <span>42!</span></p>'"
 ```
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ ___
 "By default it installs 'Core'"
 Metacello new
   baseline: 'STTemplate';
-  repository: 'github://sebastianconcept/STTemplate:v0.0.3';
+  repository: 'github://sebastianconcept/STTemplate:latest';
   load.
 
 "Optionally use `load: #('Core' 'Tests')`" 
@@ -44,7 +44,7 @@ Metacello new
 Or as dependency in your `Baseline`
 
 ```smalltalk
-spec baseline: 'STTemplate' with: [ spec repository: 'github://sebastianconcept/STTemplate:v0.0.3' ]
+spec baseline: 'STTemplate' with: [ spec repository: 'github://sebastianconcept/STTemplate:latest' ]
 ```
 
 ## Description
@@ -111,7 +111,7 @@ and then `42` coming from displaying `self value + 2`"
 In each iteration, it creates another Smalltalk closure that has access
 to self as expected and uses that to display its content:"
 
-'<% 1 to: 3 do: [ :i | %><p>The Answer is <span><%= self value + 2%>!</span></p><% ] >' sttRenderOn: (#answer -> 40).
+'<% 1 to: 3 do: [ :i | %><p>The Answer is <span><%= self value + 2%>!</span></p><% ] %>' sttRenderOn: (#answer -> 40).
 "'<p>The Answer is <span>42!</span></p><p>The Answer is <span>42!</span></p><p>The Answer is <span>42!</span></p>'"
 ```
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,39 @@ Templates with the Power of Smalltalk
 
 [![Pharo 10](https://img.shields.io/badge/Pharo-10-%23aac9ff.svg)](https://pharo.org/download)
 
+## Description
+
+`STTemplate` is a Smalltalk template class.
+
+It can run Smalltalk code found between the opening (`<st`) and closing (`>`) tags when present in in the string that is the source of an STTemplate.
+
+There are two ways to have Smalltalk code executed from `STTemplate` instances:
+
+### 1. Displayed
+
+Analogous to a `printIt` (note the `=` after the opening tag `<st`):
+
+```smalltalk
+'<p><st= ''Hello '', self ></p>' sttRenderOn: 'STT'.
+"'<p>Hello STT</p>'"
+```
+
+### 2. Evaluated
+
+Analogous to a `doIt` (note the lack of `=` after the opening tag `<st`):
+
+```smalltalk
+'<p>Hello STT<st 40+2 ></p>' sttRenderOn: 'STT'.
+"'<p>Hello STT</p>'"
+
+'<p>Hello STT<st self crShow: ''Greetings from an STT closure!'' ></p>' sttRenderOn: Transcript.
+"'<p>Hello STT</p>'"
+
+"And in the Transcript you'll see:"
+
+'Greetings from an STT closure!'
+```
+
 ## Features
 
 - Content agnostic.
@@ -20,12 +53,12 @@ Templates with the Power of Smalltalk
 - Compiles content lazily only once.
 - Opening and closing tags and display token can be customized.
 ___
-1. [Description](#description)
-2. [Examples](#examples)
-3. [Install](#install)
-4. [Guides](#guides)
-5. [Performance](#performance)
-6. [Backstory](#backstory)
+
+1. [Examples](#examples)
+2. [Install](#install)
+3. [Guides](#guides)
+4. [Performance](#performance)
+5. [Backstory](#backstory)
 
 ## Install
 
@@ -45,39 +78,6 @@ Or as dependency in your `Baseline`
 
 ```smalltalk
 spec baseline: 'STTemplate' with: [ spec repository: 'github://sebastianconcept/STTemplate:v0.0.3' ]
-```
-
-## Description
-
-`STTemplate` is a Smalltalk template class.
-
-It can run Smalltalk code found between the opening (`<st`) and closing (`>`) tags when present in the content.
-
-There are two ways to have Smalltalk running from `STTemplate` instances:
-
-### 1. Displayed
-
-Analogous to a `printIt`
-
-```smalltalk
-'<p><st= ''Hello '', self ></p>' sttRenderOn: 'STT'.
-"'<p>Hello STT</p>'"
-```
-
-### 2. Evaluated
-
-Analogous to a `doIt`
-
-```smalltalk
-'<p>Hello STT<st 40+2 ></p>' sttRenderOn: 'STT'.
-"'<p>Hello STT</p>'"
-
-'<p>Hello STT<st self crShow: ''Greetings from an STT closure!'' ></p>' sttRenderOn: Transcript.
-"'<p>Hello STT</p>'"
-
-"And in the Transcript you'll see:"
-
-'Greetings from an STT closure!'
 ```
 
 ### Examples

--- a/STTemplate-Tests/STTemplateTest.class.st
+++ b/STTemplate-Tests/STTemplateTest.class.st
@@ -319,7 +319,7 @@ STTemplateTest >> testComposedWithNamedPartialsWithContext [
 		            at: #namedYield put: '<p>This content is <st= self></p>' asSTTemplate;
 		            yourself.
 
-	rendered := '<h1>Contents</h1><div><st= STT yield: #namedYield ></div>'
+	rendered := '<h1>Contents</h1><div><st STT yieldUsing: #namedYield ></div>'
 		            sttRenderOn: 42
 		            partials: partials.
 
@@ -1003,8 +1003,8 @@ STTemplateTest >> testYieldDeeperPartial [
 
 	| template partials alertsTemplate rendered expectedRendering |
 	template := '
-<div><st= STT yield: ''shared/alerts.html'' on: self><div>
-<st= STT yield: #showJob >
+<div><st STT yieldUsing: ''shared/alerts.html''><div>
+<st STT yieldUsing: #showJob >
 ' asSTTemplate.
 
 	alertsTemplate := '<div><st= self ></div><ul><li>Alerting</li></ul>'

--- a/STTemplate-Tests/STTemplateTest.class.st
+++ b/STTemplate-Tests/STTemplateTest.class.st
@@ -999,6 +999,39 @@ STTemplateTest >> testWithoutCode [
 ]
 
 { #category : #tests }
+STTemplateTest >> testYieldCustomContextUsingNamedPartial [
+
+	| rendered namedPartial |
+	namedPartial := { (#answer
+	                 ->
+	                 '<p>The answer is <%= 40 + (self at: #plus) %></p>' asSTTemplate) }
+		                asDictionary.
+
+	rendered := '<h1>Contents</h1><div><%= STT yield: self using: ''answer'' %></div>'
+		            sttRenderOn: { (#plus -> 2) } asDictionary
+		            partials: namedPartial.
+
+	self
+		assert: rendered
+		equals: '<h1>Contents</h1><div><p>The answer is 42</p></div>'
+]
+
+{ #category : #tests }
+STTemplateTest >> testYieldCustomContextUsingSinglePartial [
+
+	| rendered partial |
+	partial := '<p>The answer is <%= 40+self %></p>' asSTTemplate.
+
+	rendered := '<h1>Contents</h1><div><%= STT yield %></div>'
+		            sttRenderOn: 2
+		            partial: partial.
+
+	self
+		assert: rendered
+		equals: '<h1>Contents</h1><div><p>The answer is 42</p></div>'
+]
+
+{ #category : #tests }
 STTemplateTest >> testYieldDeeperPartial [
 
 	| template partials alertsTemplate rendered expectedRendering |

--- a/STTemplate-Tests/STTemplateTest.class.st
+++ b/STTemplate-Tests/STTemplateTest.class.st
@@ -19,22 +19,22 @@ STTemplateTest class >> jobsTableTemplate [
     </tr>
   </thead>
   <tbody>
-    <st [ |tableContext|
-      tableContext := 42 >
-      <st self jobs do: [ :job | >
+    <% [ |tableContext|
+      tableContext := 42 %>
+      <% self jobs do: [ :job | %>
       <tr
-        hx-on:click="showJob("<st= job jobId >")"
+        hx-on:click="showJob("<%= job jobId %>")"
       >
         <th>
-          <st 4+7 >
-          <st= job jobId >
+          <% 4+7 %>
+          <%= job jobId %>
         </th>
-        <td><st= job firstName ></td>
-        <td><st= tableContext asString,''-'', job effect ></td>
-        <td><st= job waitingFor ></td>
+        <td><%= job firstName %></td>
+        <td><%= tableContext asString,''-'', job effect %></td>
+        <td><%= job waitingFor %></td>
       </tr>
-      <st ] >
-    <st ] value >
+      <% ] %>
+    <% ] value %>
   </tbody>
 </table>
 '
@@ -221,7 +221,7 @@ STTemplateTest >> testCanAccessInstVarsOfTheContext [
 		                   firstName: 'Questioner';
 		                   yourself.
 	template := '<div>
-<section><st= firstName, '' '', answer asString></section>
+<section><%= firstName, '' '', answer asString %></section>
 </div>' asSTTemplate.
 
 	expectedRendering := '<div>
@@ -240,17 +240,17 @@ STTemplateTest >> testCanAccessInstVarsOfTheContextFromAPartial [
 		                   firstName: 'Questioner';
 		                   yourself.
 	template := '<div>
-<section><st STT yield: ''shared/alerts.html'' on: self></section>
-<section><st STT yield: #showJob on: self></section>
+<section><% STT yield: ''shared/alerts.html'' on: self %></section>
+<section><% STT yield: #showJob on: self %></section>
 </div>' asSTTemplate.
 
 	"With message send"
-	alertsTemplate := '<div>Beware <st= self firstName></div><ul><li>Alert 1</li></ul>'
+	alertsTemplate := '<div>Beware <%= self firstName %></div><ul><li>Alert 1</li></ul>'
 		                  asSTTemplate.
 	partials := { 
 		            (#shared
 		             -> { ('alerts.html' -> alertsTemplate) } asDictionary).
-		            (#showJob -> '<p><st= 42 ></p>' asSTTemplate) }
+		            (#showJob -> '<p><%= 42 %></p>' asSTTemplate) }
 		            asDictionary.
 
 	expectedRendering := '<div>
@@ -261,12 +261,12 @@ STTemplateTest >> testCanAccessInstVarsOfTheContextFromAPartial [
 	self assert: rendered equals: expectedRendering.
 
 	"With direct access to the instVar"
-	alertsTemplate := '<div>Beware <st= firstName></div><ul><li>Alert 1</li></ul>'
+	alertsTemplate := '<div>Beware <%= firstName %></div><ul><li>Alert 1</li></ul>'
 		                  asSTTemplate.
 	partials := { 
 		            (#shared
 		             -> { ('alerts.html' -> alertsTemplate) } asDictionary).
-		            (#showJob -> '<p><st= 42 ></p>' asSTTemplate) }
+		            (#showJob -> '<p><%= 42 %></p>' asSTTemplate) }
 		            asDictionary.		
 	rendered := template renderOn: templateContext partials: partials.
 	self assert: rendered equals: expectedRendering.
@@ -302,7 +302,7 @@ STTemplateTest >> testComposedWithNamedPartials [
 		            at: #namedYield put: '<p>This content</p>' asSTTemplate;
 		            yourself.
 
-	rendered := '<h1>Contents</h1><div><st= STT yield: #namedYield ></div>'
+	rendered := '<h1>Contents</h1><div><% STT yield: #namedYield %></div>'
 		            sttRenderOn: 42
 		            partials: partials.
 
@@ -316,10 +316,10 @@ STTemplateTest >> testComposedWithNamedPartialsWithContext [
 
 	| rendered partials |
 	partials := Dictionary new
-		            at: #namedYield put: '<p>This content is <st= self></p>' asSTTemplate;
+		            at: #namedYield put: '<p>This content is <%= self%></p>' asSTTemplate;
 		            yourself.
 
-	rendered := '<h1>Contents</h1><div><st= STT yield: #namedYield ></div>'
+	rendered := '<h1>Contents</h1><div><%= STT yield: #namedYield %></div>'
 		            sttRenderOn: 42
 		            partials: partials.
 
@@ -332,9 +332,9 @@ STTemplateTest >> testComposedWithNamedPartialsWithContext [
 STTemplateTest >> testComposedWithPartial [
 
 	| rendered partial |
-	partial := '<p>The answer is <st= 40+2></p>' asSTTemplate.
+	partial := '<p>The answer is <%= 40+2 %></p>' asSTTemplate.
 
-	rendered := '<h1>Contents</h1><div><st= STT yield ></div>'
+	rendered := '<h1>Contents</h1><div><%= STT yield %></div>'
 		            sttRenderOn: nil
 		            partial: partial.
 
@@ -347,9 +347,9 @@ STTemplateTest >> testComposedWithPartial [
 STTemplateTest >> testComposedWithPartialWithCustomizedContext [
 
 	| rendered partial |
-	partial := '<p>The answer is <st= 40+self></p>' asSTTemplate.
+	partial := '<p>The answer is <%= 40+self %></p>' asSTTemplate.
 
-	rendered := '<h1>Contents</h1><div><st= STT yield ></div>'
+	rendered := '<h1>Contents</h1><div><%= STT yield %></div>'
 		            sttRenderOn: 2
 		            partial: partial.
 
@@ -364,10 +364,10 @@ STTemplateTest >> testComposedWithPartialsWithCustomizedContext [
 	| rendered partials |
 	partials := Dictionary new
 		            at: #namedYield
-		            put: '<p>This content is <st= self ></p>' asSTTemplate;
+		            put: '<p>This content is <%= self %></p>' asSTTemplate;
 		            yourself.
 
-	rendered := '<h1>Contents</h1><div><st= STT yield: #namedYield on: #(#programmatic #dynamic) atRandom ></div>'
+	rendered := '<h1>Contents</h1><div><% STT yield: #namedYield on: #(#programmatic #dynamic) atRandom %></div>'
 		            sttRenderOn: nil
 		            partials: partials.
 
@@ -384,7 +384,7 @@ STTemplateTest >> testComposedWithUnnamedPartial [
 	| rendered partial |
 	partial := '<p>This content</p>' asSTTemplate.
 
-	rendered := '<h1>Contents</h1><div><st= STT yield ></div>'
+	rendered := '<h1>Contents</h1><div><% STT yield %></div>'
 		            sttRenderOn: 42
 		            partial: partial.
 	self
@@ -397,21 +397,21 @@ STTemplateTest >> testDetectsCustomClosingTag [
 
 	| stt |
 	STTemplate options at: #closingTag put: '/!?itEndsHere}}'.
-	stt := '<st  ><span>42</span>' asSTTemplate.
+	stt := '<%  %><span>42</span>' asSTTemplate.
 	self should: [ stt renderOn: nil ] raise: STTemplateCompilationError.
-	stt := '<st  /!?itEndsHere}}<span>41</span>' asSTTemplate.
+	stt := '<%  /!?itEndsHere}}<span>41</span>' asSTTemplate.
 	self assert: (stt renderOn: nil) equals: '<span>41</span>'.
 
-	STTemplate options at: #closingTag put: '%>'.
-	stt := '<st  %><span>42</span>' asSTTemplate.
+	STTemplate options at: #closingTag put: '~>'.
+	stt := '<%  ~><span>42</span>' asSTTemplate.
 	self assert: (stt renderOn: nil) equals: '<span>42</span>'.
 
 	STTemplate options at: #closingTag put: '?>'.
-	stt := '<span><st= 42 ?></span>' asSTTemplate.
+	stt := '<span><%= 42 ?></span>' asSTTemplate.
 	self assert: (stt renderOn: nil) equals: '<span>42</span>'.
 
 	STTemplate options at: #closingTag put: '-->'.
-	stt := '<span><st= self --></span>' asSTTemplate.
+	stt := '<span><%= self --></span>' asSTTemplate.
 	self assert: (stt renderOn: 42) equals: '<span>42</span>'
 ]
 
@@ -467,7 +467,7 @@ STTemplateTest >> testDetectsMissingClosingTag [
 
 	| stt |
 	stt := '<tbody>
-    <st self jobs do: [ :job |' asSTTemplate.
+    <% self jobs do: [ :job |' asSTTemplate.
 
 	"Not exactly detecting that but failing correctly."
 	self should: [ stt renderOn: nil ] raise: STTemplateCompilationError
@@ -477,7 +477,7 @@ STTemplateTest >> testDetectsMissingClosingTag [
 STTemplateTest >> testDisplayValueFromCustomAttribute [
 
 	| stt context |
-	stt := '<div data-custom="questionEverything(<st= self at: #answer>)">Ask</div>'
+	stt := '<div data-custom="questionEverything(<%= self at: #answer %>)">Ask</div>'
 		       asSTTemplate.
 
 	context := Dictionary new
@@ -498,7 +498,7 @@ STTemplateTest >> testEmpty [
 STTemplateTest >> testEnclosingCode [
 
 	self
-		assert: ('<st= 42 ><p>Hello</p>' sttRenderOn: nil)
+		assert: ('<%= 42 %><p>Hello</p>' sttRenderOn: nil)
 		equals: '42<p>Hello</p>'
 ]
 
@@ -506,11 +506,11 @@ STTemplateTest >> testEnclosingCode [
 STTemplateTest >> testEnclosingNoCode [
 
 	self
-		assert: ('<p>Hello</p><st >' sttRenderOn: nil)
+		assert: ('<p>Hello</p><% %>' sttRenderOn: nil)
 		equals: '<p>Hello</p>'.
 
 	self
-		assert: ('<p>Hello</p><span><st= ></span>' sttRenderOn: nil)
+		assert: ('<p>Hello</p><span><%= %></span>' sttRenderOn: nil)
 		equals: '<p>Hello</p><span></span>'
 ]
 
@@ -518,7 +518,7 @@ STTemplateTest >> testEnclosingNoCode [
 STTemplateTest >> testEnclosingNoCodeAfterElement [
 
 	| stt |
-	stt := '<p>Hello</p><st >' asSTTemplate.
+	stt := '<p>Hello</p><% %>' asSTTemplate.
 	self shouldnt: [ stt asSmalltalkSource ] raise: STTError.
 	self assert: (stt renderOn: nil) equals: '<p>Hello</p>'
 ]
@@ -527,7 +527,7 @@ STTemplateTest >> testEnclosingNoCodeAfterElement [
 STTemplateTest >> testEnclosingNoCodeBeforeElement [
 
 	| rendered |
-	rendered := '<st ><p>Hello</p>' sttRenderOn: nil.
+	rendered := '<% %><p>Hello</p>' sttRenderOn: nil.
 	self assert: rendered  equals: '<p>Hello</p>'
 ]
 
@@ -535,7 +535,7 @@ STTemplateTest >> testEnclosingNoCodeBeforeElement [
 STTemplateTest >> testEnclosingNoCodeEnclosingElement [
 
 	self
-		should: [ '<st <p>Hello</p> >' asSTTemplate renderOn: nil ]
+		should: [ '<% <p>Hello</p> %>' asSTTemplate renderOn: nil ]
 		raise: STTemplateCompilationError
 ]
 
@@ -553,17 +553,17 @@ STTemplateTest >> testNestedClosure [
 
 	| stt shouldRender |
 	stt := STTemplate on: '
-		<st [ | answer | 
+		<% [ | answer | 
 			answer := self.
-		>
+		%>
 			<ul>
-				<li><st= ''What is the answer'' ></li> 
-				<li>to the question? <st= answer asString ></li> 
-				<st [ answer := answer + 1>
-					<li>and the answer +1? That would be: <st= answer asString ></li>
-				<st ] value >
+				<li><%= ''What is the answer'' %></li> 
+				<li>to the question? <%= answer asString %></li> 
+				<% [ answer := answer + 1 %>
+					<li>and the answer +1? That would be: <%= answer asString %></li>
+				<% ] value %>
 			</ul>
-		<st ] value >'.
+		<% ] value %>'.
 
 	shouldRender := '
 		
@@ -583,16 +583,16 @@ STTemplateTest >> testNestedClosureSource [
 
 	| stt shouldRender |
 	stt := STTemplate on: '
-		<st [ | answer | 
-			answer := self>
+		<% [ | answer | 
+			answer := self %>
 			<ul>
-				<li><st= ''What is the answer'' ></li> 
-				<li>to the question? <st= answer asString ></li> 
-				<st [ answer := answer + 1>
-					<li>and the answer +1? That would be: <st= answer asString ></li>
-				<st ] value>
+				<li><%= ''What is the answer'' %></li> 
+				<li>to the question? <%= answer asString %></li> 
+				<% [ answer := answer + 1%>
+					<li>and the answer +1? That would be: <%= answer asString%></li>
+				<% ] value %>
 			</ul>
-		<st ] value>'.
+		<% ] value %>'.
 
 	shouldRender := '_anonymousRenderer
 | out result |
@@ -602,7 +602,7 @@ out := String new writeStream.
 out nextPutAll: ''
 		''.
  [ | answer | 
-			answer := self.
+			answer := self .
 out nextPutAll: ''
 			<ul>
 				<li>''.
@@ -617,15 +617,15 @@ out nextPutAll: ''</li>
  [ answer := answer + 1.
 out nextPutAll: ''
 					<li>and the answer +1? That would be: ''.
-result := [  answer asString  ] value.
+result := [  answer asString ] value.
 out nextPutAll: result asString.
 out nextPutAll: ''</li>
 				''.
- ] value.
+ ] value .
 out nextPutAll: ''
 			</ul>
 		''.
- ] value.
+ ] value .
 out contents ]'.
 	self assert: stt asSmalltalkSource equals: shouldRender
 ]
@@ -635,12 +635,12 @@ STTemplateTest >> testNestedDisplayValueFromCustomAttribute [
 
 	| stt context shouldRender source |
 	source := '<ul>
-			<st self do: [ :dic | >
+			<% self do: [ :dic | %>
 				<li>
-					<div data-custom="questionEverything(<st= dic at: #answer >)">
-					<span>Ask, </span><span><st= dic at: #what ></span></div>
+					<div data-custom="questionEverything(<%= dic at: #answer %>)">
+					<span>Ask, </span><span><%= dic at: #what %></span></div>
 				</li>
-			<st ] >
+			<% ] %>
 		</ul>' trimmed copyWithoutAll: { 
 			          Character cr.
 			          Character lf.
@@ -668,7 +668,7 @@ STTemplateTest >> testPartialWithSingleQuote [
 	partials := { (#withStringToEscapeQuote
 	             -> '<p>That''s also it!</p>' asSTTemplate) }
 		            asDictionary.
-	template := '<div><p>That''s it and</p><st STT yield: #withStringToEscapeQuote ></div>'
+	template := '<div><p>That''s it and</p><% STT yield: #withStringToEscapeQuote %></div>'
 		            asSTTemplate.
 
 	self
@@ -696,21 +696,21 @@ STTemplateTest >> testRenderComposedRenderedWithoutContext [
 		            at: #showJob put: '
 <div>
 	<h1>Partial content for #showJob</h1>
-	<div><st STT yield: #jobDetails on: self></div>
+	<div><% STT yield: #jobDetails on: self %></div>
 </div>
 ' asSTTemplate;
 		            at: #jobDetails
 		            put:
-			            '<p>Job ID: <span><st= self jobId></span></p><p>Job description: <span><st= self description></span></p>'
+			            '<p>Job ID: <span><%= self jobId %></span></p><p>Job description: <span><%= self description %></span></p>'
 				            asSTTemplate;
 		            yourself.
 	template := '
 <ul>
-	<st self jobs do: [ :job | >
+	<% self jobs do: [ :job | %>
 		<li>
-			<st= STT yield: #showJob on: job>
+			<%= STT yield: #showJob on: job %>
 		</li>
-	<st ]>
+	<% ] %>
 </ul>
 ' asSTTemplate.
 
@@ -747,8 +747,8 @@ STTemplateTest >> testRenderComposedRenderedWithoutContext [
 STTemplateTest >> testRenderComposedSnippetWithNamedYield [
 
 	| template partials |
-	template := '<st= STT yield: #showJob >' asSTTemplate.
-	partials := { (#showJob -> '<st= 42 >' asSTTemplate) } asDictionary.
+	template := '<%= STT yield: #showJob %>' asSTTemplate.
+	partials := { (#showJob -> '<%= 42 %>' asSTTemplate) } asDictionary.
 
 	self
 		assert: template asSmalltalkSnippet
@@ -773,7 +773,7 @@ STTemplateTest >> testRenderComposedSnippetWithoutContext [
 		            at: #showJob put: '
 <div>
 	<h1>Partial content for #showJob</h1>
-	<p><st STT yield: #jobDetails ></p>
+	<p><% STT yield: #jobDetails %></p>
 </div>
 ' asSTTemplate;
 		            at: #jobDetails
@@ -781,11 +781,11 @@ STTemplateTest >> testRenderComposedSnippetWithoutContext [
 		            yourself.
 	template := '
 <ul>
-	<st self jobs do: [ :job | >
+	<% self jobs do: [ :job | %>
 		<li>
-			<st= STT yield: #showJob >
+			<%= STT yield: #showJob %>
 		</li>
-	<st ] >
+	<% ] %>
 </ul>
 ' asSTTemplate.
 
@@ -796,15 +796,15 @@ STTemplateTest >> testRenderComposedSnippetWithoutContext [
 STTemplateTest >> testRenderDoublyComposedSnippetWithNamedYield [
 
 	| template partials |
-	template := '<main><st= STT yield: #showJob ></main>' asSTTemplate.
+	template := '<main><%= STT yield: #showJob %></main>' asSTTemplate.
 	partials := { 
 		            (#showJob
 		             ->
-		             '<section><st= STT yield: #jobDetails ></section>'
+		             '<section><%= STT yield: #jobDetails %></section>'
 			             asSTTemplate).
 		            (#jobDetails
 		             ->
-		             '<div><st= ''This is the #jobDetails content'' ></div>'
+		             '<div><%= ''This is the #jobDetails content'' %></div>'
 			             asSTTemplate) } asDictionary.
 
 	self
@@ -823,24 +823,24 @@ STTemplateTest >> testRenderFourLevelsComposition [
 		                   description: 'job 1';
 		                   thing: 'something visual';
 		                   yourself.
-	template := '<main><st= STT yield: #levelOne ></main>' asSTTemplate.
+	template := '<main><%= STT yield: #levelOne %></main>' asSTTemplate.
 	partials := { 
 		            (#levelOne -> '<section>
-			<p><st= ''This is the #levelOne content (I include #levelTwo).'' ></p>
-			<div><st= STT yield: #levelTwo on: self></div>
+			<p><%= ''This is the #levelOne content (I include #levelTwo).'' %></p>
+			<div><%= STT yield: #levelTwo on: self%></div>
 						</section>' asSTTemplate).
 		            (#levelTwo -> '<div>
-			<p><st= ''This is the #levelTwo content (I include #levelThree).'' ></p>
-			<div><st= STT yield: #levelThree on: self></div>
+			<p><%= ''This is the #levelTwo content (I include #levelThree).'' %></p>
+			<div><%= STT yield: #levelThree on: self%></div>
 			</div>' asSTTemplate).
 		            (#levelThree -> '<div>
-			<p><st= ''This is the #levelThree content (I include #levelFour).'' ></p>
-			<div><st= STT yield: #levelFour on: self></div>
+			<p><%= ''This is the #levelThree content (I include #levelFour).'' %></p>
+			<div><%= STT yield: #levelFour on: self%></div>
 			</div>' asSTTemplate).
 		            (#levelFour
 		             ->
-		             '<p><st= ''This is the #levelFour content.'' ></p>
-						<p><st= self thing></p>'
+		             '<p><%= ''This is the #levelFour content.'' %></p>
+						<p><%= self thing%></p>'
 			             asSTTemplate) } asDictionary.
 
 	self
@@ -862,8 +862,8 @@ STTemplateTest >> testRenderFourLevelsComposition [
 STTemplateTest >> testRenderSimpleNamedYieldSnippetWithoutDisplayToken [
 
 	| template partials |
-	template := '<st STT yield: #showJob >' asSTTemplate.
-	partials := { (#showJob -> '<st= 42 >' asSTTemplate) } asDictionary.
+	template := '<% STT yield: #showJob %>' asSTTemplate.
+	partials := { (#showJob -> '<%= 42 %>' asSTTemplate) } asDictionary.
 
 	self
 		assert: template asSmalltalkSnippet
@@ -874,19 +874,19 @@ STTemplateTest >> testRenderSimpleNamedYieldSnippetWithoutDisplayToken [
 STTemplateTest >> testRenderTriplyComposedSnippetWithNamedYield [
 
 	| template partials |
-	template := '<main><st= STT yield: #showJob ></main>' asSTTemplate.
+	template := '<main><%= STT yield: #showJob %></main>' asSTTemplate.
 	partials := { 
 		            (#showJob
 		             ->
-		             '<section><st= STT yield: #jobInfo ></section>'
+		             '<section><%= STT yield: #jobInfo %></section>'
 			             asSTTemplate).
 		            (#jobInfo
 		             ->
-			             '<div><p><st= ''This is the #jobInfo content.'' ></p></div><st= STT yield: #jobDetails ></div></div>'
+			             '<div><p><%= ''This is the #jobInfo content.'' %></p></div><%= STT yield: #jobDetails %></div></div>'
 				             asSTTemplate).
 		            (#jobDetails
 		             ->
-		             '<div><st= ''This is the #jobDetails content'' ></div>'
+		             '<div><%= ''This is the #jobDetails content'' %></div>'
 			             asSTTemplate) } asDictionary.
 
 	self
@@ -904,19 +904,19 @@ STTemplateTest >> testRenderTriplyComposedWithNamedYield [
 		                   jobId: 42;
 		                   description: 'job 1';
 		                   yourself.
-	template := '<main><st= STT yield: #showJob ></main>' asSTTemplate.
+	template := '<main><%= STT yield: #showJob %></main>' asSTTemplate.
 	partials := { 
 		            (#showJob
 		             ->
-		             '<section><st= STT yield: #jobInfo ></section>'
+		             '<section><%= STT yield: #jobInfo %></section>'
 			             asSTTemplate).
 		            (#jobInfo
 		             ->
-			             '<div><p><st= ''This is the #jobInfo content.'' ></p></div><st= STT yield: #jobDetails ></div></div>'
+			             '<div><p><%= ''This is the #jobInfo content.'' %></p></div><%= STT yield: #jobDetails %></div></div>'
 				             asSTTemplate).
 		            (#jobDetails
 		             ->
-			             '<div><st= ''Job Details: jobId is {1} and its description is {2}'' format: { self jobId asString. self description } ></div>'
+			             '<div><%= ''Job Details: jobId is {1} and its description is {2}'' format: { self jobId asString. self description } %></div>'
 				             asSTTemplate) } asDictionary.
 
 	self
@@ -929,7 +929,7 @@ STTemplateTest >> testRenderTriplyComposedWithNamedYield [
 STTemplateTest >> testSourceForEnclosingNoCodeBeforeElement [
 
 	| template |
-	template := '<st 6+5 ><p>Hello</p>' asSTTemplate.
+	template := '<% 6+5 %><p>Hello</p>' asSTTemplate.
 	self assert: template asSmalltalkSource equals: '_anonymousRenderer
 | out result |
 out := String new writeStream.
@@ -945,9 +945,9 @@ STTemplateTest >> testSourceForValueFromTempVar [
 
 	| source |
 	source := '<p>Hello</p><span>
-		<st= |answer| 
+		<%= |answer| 
 			answer := 42. 
-			answer >
+			answer %>
 		</span>'.
 
 	self
@@ -982,9 +982,9 @@ STTemplateTest >> testValueFromTempVar [
 
 	| source |
 	source := '<p>Hello</p><span>
-		<st= |answer| 
+		<%= |answer| 
 			answer := 42. 
-			answer >
+			answer %>
 		</span>'.
 
 	self assert: (source sttRenderOn: nil) equals: '<p>Hello</p><span>
@@ -1003,16 +1003,16 @@ STTemplateTest >> testYieldDeeperPartial [
 
 	| template partials alertsTemplate rendered expectedRendering |
 	template := '
-<div><st= STT yield: ''shared/alerts.html'' on: self><div>
-<st= STT yield: #showJob >
+<div><%= STT yield: ''shared/alerts.html'' on: self%><div>
+<%= STT yield: #showJob %>
 ' asSTTemplate.
 
-	alertsTemplate := '<div><st= self ></div><ul><li>Alerting</li></ul>'
+	alertsTemplate := '<div><%= self %></div><ul><li>Alerting</li></ul>'
 		                  asSTTemplate.
-	partials := { 
+	partials := {
 		            (#shared
 		             -> { ('alerts.html' -> alertsTemplate) } asDictionary).
-		            (#showJob -> '<p><st= 42 ></p>' asSTTemplate) }
+		            (#showJob -> '<p><%= 42 %></p>' asSTTemplate) }
 		            asDictionary.
 
 	expectedRendering := '

--- a/STTemplate/STT.class.st
+++ b/STTemplate/STT.class.st
@@ -77,17 +77,6 @@ STT class >> yield: aContext using: aNamedTemplateToYield [
 ]
 
 { #category : #public }
-STT class >> yieldPartial: anSTTemplate on: aContext [
-
-	| renderingContext outStream result |
-	self deprecated: ' use yield:using:'.	
-	renderingContext := STTCurrentRenderingContext value.
-	outStream := STTCurrentRenderingStream value.
-	result := anSTTemplate renderOn: aContext.
-	outStream nextPutAll: result
-]
-
-{ #category : #public }
 STT class >> yieldUsing: aNamedPartialToYield [
 
 	| renderingContext |

--- a/STTemplate/STT.class.st
+++ b/STTemplate/STT.class.st
@@ -30,6 +30,7 @@ STT class >> getTemplateFrom: aNamedPartialToYield in: partialsDictionaryish [
 STT class >> yield: aNamedPartialToYield [
 
 	| renderingContext |
+	self deprecated: 'use yieldUsing: aTemplateName'.
 	renderingContext := STTCurrentRenderingContext value.
 	renderingContext ifNil: [ 
 		STTError signal:
@@ -40,6 +41,32 @@ STT class >> yield: aNamedPartialToYield [
 
 { #category : #public }
 STT class >> yield: aNamedPartialToYield on: aContext [
+
+	| renderingContext template outStream result |
+	self deprecated: 'use yield:using:'.
+	renderingContext := STTCurrentRenderingContext value.
+	template := self
+		            getTemplateFrom: aNamedPartialToYield
+		            in: renderingContext partials.
+	outStream := STTCurrentRenderingStream value.
+	result := template
+		          renderOn: aContext
+		          partials: renderingContext partials.
+	outStream nextPutAll: result
+]
+
+{ #category : #public }
+STT class >> yield: aContext template: anSTTemplate [
+
+	| renderingContext outStream result |
+	renderingContext := STTCurrentRenderingContext value.
+	outStream := STTCurrentRenderingStream value.
+	result := anSTTemplate renderOn: aContext.
+	outStream nextPutAll: result
+]
+
+{ #category : #public }
+STT class >> yield: aContext using: aNamedPartialToYield [
 
 	| renderingContext template outStream result |
 	renderingContext := STTCurrentRenderingContext value.
@@ -57,8 +84,23 @@ STT class >> yield: aNamedPartialToYield on: aContext [
 STT class >> yieldPartial: anSTTemplate on: aContext [
 
 	| renderingContext outStream result |
+	self deprecated: 'use yield:template:'.
 	renderingContext := STTCurrentRenderingContext value.
 	outStream := STTCurrentRenderingStream value.
 	result := anSTTemplate renderOn: aContext.
 	outStream nextPutAll: result
+]
+
+{ #category : #public }
+STT class >> yieldUsing: aNamedPartialToYield [
+
+	| renderingContext |
+	renderingContext := STTCurrentRenderingContext value.
+	renderingContext ifNil: [ 
+		STTError signal:
+			('Template context unreacheable while trying to yield {1}' format:
+				 { aNamedPartialToYield asString }) ].
+	self
+		yield: renderingContext templateContext
+		using: aNamedPartialToYield
 ]

--- a/STTemplate/STT.class.st
+++ b/STTemplate/STT.class.st
@@ -56,28 +56,23 @@ STT class >> yield: aNamedPartialToYield on: aContext [
 ]
 
 { #category : #public }
-STT class >> yield: aContext template: anSTTemplate [
+STT class >> yield: aContext template: anSTTemplate on: writeStream [
 
-	| renderingContext outStream result |
-	renderingContext := STTCurrentRenderingContext value.
-	outStream := STTCurrentRenderingStream value.
-	result := anSTTemplate renderOn: aContext.
-	outStream nextPutAll: result
+	writeStream nextPutAll: (anSTTemplate renderOn: aContext)
 ]
 
 { #category : #public }
 STT class >> yield: aContext using: aNamedPartialToYield [
 
-	| renderingContext template outStream result |
+	| renderingContext template |
 	renderingContext := STTCurrentRenderingContext value.
 	template := self
 		            getTemplateFrom: aNamedPartialToYield
 		            in: renderingContext partials.
-	outStream := STTCurrentRenderingStream value.
-	result := template
-		          renderOn: aContext
-		          partials: renderingContext partials.
-	outStream nextPutAll: result
+	self
+		yield: aContext
+		template: template
+		on: STTCurrentRenderingStream value
 ]
 
 { #category : #public }

--- a/STTemplate/STT.class.st
+++ b/STTemplate/STT.class.st
@@ -8,7 +8,7 @@ Class {
 }
 
 { #category : #public }
-STT class >> getTemplateFrom: aNamedPartialToYield in: partialsDictionaryish [
+STT class >> getTemplateFrom: aNamedPartialToYield in: templatesDictionaryish [
 
 	| parts selector reminder missing |
 	parts := aNamedPartialToYield substrings: '/'.
@@ -21,15 +21,16 @@ STT class >> getTemplateFrom: aNamedPartialToYield in: partialsDictionaryish [
 		reminder := '/' join: parts allButFirst.
 		^ self
 			  getTemplateFrom: reminder
-			  in: (partialsDictionaryish at: selector ifAbsent: missing) ].
+			  in: (templatesDictionaryish at: selector ifAbsent: missing) ].
 
-	^ partialsDictionaryish at: parts first ifAbsent: missing
+	^ templatesDictionaryish at: parts first ifAbsent: missing
 ]
 
 { #category : #public }
 STT class >> yield: aNamedPartialToYield [
 
 	| renderingContext |
+	self deprecated: ' use yield:using:'.
 	renderingContext := STTCurrentRenderingContext value.
 	renderingContext ifNil: [ 
 		STTError signal:
@@ -42,21 +43,44 @@ STT class >> yield: aNamedPartialToYield [
 STT class >> yield: aNamedPartialToYield on: aContext [
 
 	| renderingContext template outStream result |
+	self deprecated: ' use yield:using:'.	
 	renderingContext := STTCurrentRenderingContext value.
 	template := self
 		            getTemplateFrom: aNamedPartialToYield
-		            in: renderingContext partials.
+		            in: renderingContext templates.
 	outStream := STTCurrentRenderingStream value.
 	result := template
 		          renderOn: aContext
-		          partials: renderingContext partials.
+		          partials: renderingContext templates.
 	outStream nextPutAll: result
+]
+
+{ #category : #public }
+STT class >> yield: aContext template: anSTTemplate on: writeStream [
+
+	writeStream nextPutAll: (anSTTemplate renderOn: aContext)
+]
+
+{ #category : #public }
+STT class >> yield: aContext using: aNamedTemplateToYield [
+
+	| renderingContext template |
+	renderingContext := STTCurrentRenderingContext value.
+	template := self
+		            getTemplateFrom: aNamedTemplateToYield
+		            in: renderingContext templates.
+
+	self
+		yield: aContext
+		template: template
+		on: STTCurrentRenderingStream value
 ]
 
 { #category : #public }
 STT class >> yieldPartial: anSTTemplate on: aContext [
 
 	| renderingContext outStream result |
+	self deprecated: ' use yield:using:'.	
 	renderingContext := STTCurrentRenderingContext value.
 	outStream := STTCurrentRenderingStream value.
 	result := anSTTemplate renderOn: aContext.

--- a/STTemplate/STTRenderingContext.class.st
+++ b/STTemplate/STTRenderingContext.class.st
@@ -9,34 +9,34 @@ Class {
 	#superclass : #Object,
 	#instVars : [
 		'templateContext',
-		'partials'
+		'templates'
 	],
 	#category : #'STTemplate-Core'
 }
 
 { #category : #'instance creation' }
-STTRenderingContext class >> on: aTemplateContext partials: partialsDictionarish [
+STTRenderingContext class >> on: aTemplateContext templates: templatesDictionarish [
 
 	^ self new
 		  initializeOn: aTemplateContext
-		  partials: partialsDictionarish
+		  templates: templatesDictionarish
 ]
 
 { #category : #initialization }
-STTRenderingContext >> initializeOn: aTemplateContext partials: partialsDictionarish [
+STTRenderingContext >> initializeOn: aTemplateContext templates: templatesDictionarish [
 
 	templateContext := aTemplateContext.
-	partials := partialsDictionarish
-]
-
-{ #category : #accessing }
-STTRenderingContext >> partials [
-
-	^ partials
+	templates := templatesDictionarish
 ]
 
 { #category : #accessing }
 STTRenderingContext >> templateContext [
 
 	^ templateContext
+]
+
+{ #category : #accessing }
+STTRenderingContext >> templates [
+
+	^ templates
 ]

--- a/STTemplate/STTemplate.class.st
+++ b/STTemplate/STTemplate.class.st
@@ -393,7 +393,7 @@ STTemplate >> isToBeDisplayed: sourceStream displayToken: displayToken [
 STTemplate >> isUnnamedYield: aSmalltalkExpression [
 
 	^ (aSmalltalkExpression indexOfSubCollection: 'yield') > 0 and: [ 
-		  (aSmalltalkExpression indexOfSubCollection: 'yield:') isZero ]
+		  (aSmalltalkExpression indexOfSubCollection: 'yieldUsing:') isZero ]
 ]
 
 { #category : #actions }
@@ -427,6 +427,7 @@ STTemplate >> render [
 STTemplate >> renderNamedYieldsFrom: smalltalkExpression on: rendered [
 
 	| partialRenderingSnippet |
+
 	partialRenderingSnippet := String streamContents: [ :str | 
 		                           str nextPutAll: smalltalkExpression.
 		                           self
@@ -454,7 +455,6 @@ STTemplate >> renderOn: anObject partial: partial [
 	The STTCurrentRenderingContext dynamic variable and STTCurrentRenderingContext gives them
 	access to complete its rendering process."
 
-	self deprecated: 'not used'.
 	^ self
 		  renderOn: anObject
 		  partials: { (#_yield -> partial) } asDictionary
@@ -557,7 +557,8 @@ STTemplate >> renderYieldOn: rendered [
 	| partialRenderingSnippet smalltalkExpression |
 	"Preserves the context in which the partial should be rendered
 	and makes it available by grabbing it from the expected private selector key."
-	smalltalkExpression := 'STT yield: #_yield on: self'.
+
+	smalltalkExpression := 'STT yieldUsing: #_yield'.
 
 	partialRenderingSnippet := String streamContents: [ :str | 
 		                           str nextPutAll: smalltalkExpression.

--- a/STTemplate/STTemplate.class.st
+++ b/STTemplate/STTemplate.class.st
@@ -149,7 +149,7 @@ STTemplate class >> initializeExceptionalTerminationSymbols [
 { #category : #initialization }
 STTemplate class >> initializeOptions [
 
-	self beSST.
+	self beLikeERB.
 	^ options
 ]
 

--- a/STTemplate/STTemplate.class.st
+++ b/STTemplate/STTemplate.class.st
@@ -388,21 +388,21 @@ STTemplate >> renderOn: anObject [
 ]
 
 { #category : #actions }
-STTemplate >> renderOn: anObject partial: partial [
+STTemplate >> renderOn: anObject partial: aSTTemplate [
 
 	"Answer the result of rendering the receiver using anObject as template context
-	and the given partial to be yield in the template.
+	and the given aSTTemplate as partial to be yield in the (main)template.
 	The partials are nothing but sub-templates that have also access to the template context.
 	The STTCurrentRenderingContext dynamic variable and STTCurrentRenderingContext gives them
 	access to complete its rendering process."
 
 	^ self
 		  renderOn: anObject
-		  partials: { (#_yield -> partial) } asDictionary
+		  partials: { (#_yield -> aSTTemplate) } asDictionary
 ]
 
 { #category : #actions }
-STTemplate >> renderOn: anObject partials: partialsDictionarish [
+STTemplate >> renderOn: anObject partials: templatesDictionarish [
 
 	"Answer the result of rendering the receiver using anObject as template context
 	and the given partials.
@@ -415,7 +415,7 @@ STTemplate >> renderOn: anObject partials: partialsDictionarish [
 			  | renderingContext |
 			  renderingContext := STTRenderingContext
 				                      on: anObject
-				                      partials: partialsDictionarish.
+				                      templates: templatesDictionarish.
 			  STTCurrentRenderingContext value: renderingContext during: [ 
 				  (self compiledMethodOn: anObject)
 					  valueWithReceiver: anObject

--- a/STTemplate/STTemplate.class.st
+++ b/STTemplate/STTemplate.class.st
@@ -260,18 +260,6 @@ STTemplate >> asSmalltalkSource [
 ]
 
 { #category : #actions }
-STTemplate >> basicCompile [
-
-	^ Smalltalk compiler
-		  source: self asSmalltalkSource;
-		  context: nil;
-		  failBlock: [ ^ nil ];
-		  noPattern: true;
-		  options: #( + optionParseErrors - optionSkipSemanticWarnings );
-		  compile
-]
-
-{ #category : #actions }
 STTemplate >> basicCompileOn: anObject [
 
 	^ anObject class compiler
@@ -279,19 +267,6 @@ STTemplate >> basicCompileOn: anObject [
 		  failBlock: [ ^ nil ];
 		  context: nil;
 		  compile
-]
-
-{ #category : #actions }
-STTemplate >> compile [
-
-	"Answers the compiled method resulting for this template.
-	Catches syntax error notifications to signal STTemplateCompilationError 
-	so applications can define how to handle that issue."
-
-	self deprecated: 'use compileOn: anObject'.
-	^ [ self basicCompile ]
-		  on: SyntaxErrorNotification
-		  do: [ :x | STTemplateCompilationError signal: x messageText ]
 ]
 
 { #category : #actions }
@@ -307,35 +282,9 @@ STTemplate >> compileOn: anObject [
 ]
 
 { #category : #accessing }
-STTemplate >> compiledMethod [
-
-	self deprecated: 'use compiledMethodOn:'.
-	^ compiledMethod ifNil: [ self initializeCompiledMethod ]
-]
-
-{ #category : #accessing }
 STTemplate >> compiledMethodOn: anObject [
 
 	^ compiledMethod ifNil: [ self initializeCompiledMethodOn: anObject ]
-]
-
-{ #category : #accessing }
-STTemplate >> getPartialNameFrom: smalltalkExpression [
-
-	"Answer the name of the partial in the given smalltalkExpression.
-
-	A template of a possible partial named 'showJobs' would look like this:
-	
-	<st= STT yield: #showJob >
-	"
-
-	| src |
-	self deprecated: 'not needed anymore'.
-	src := smalltalkExpression readStream.
-	src upTo: $#.
-
-	^ String streamContents: [ :s | 
-		  [ src peek isAlphaNumeric ] whileTrue: [ s nextPut: src next ] ]
 ]
 
 { #category : #testing }
@@ -355,13 +304,6 @@ STTemplate >> hasDisplayToken: token at: anInteger [
 STTemplate >> hasNamedYield: aSmalltalkExpression [
 
 	^ (aSmalltalkExpression indexOfSubCollection: 'yield:') > 0
-]
-
-{ #category : #initialization }
-STTemplate >> initializeCompiledMethod [
-
-	self deprecated: 'use initializeCompiledMethodOn:'.
-	^ compiledMethod := self compile
 ]
 
 { #category : #initialization }
@@ -449,12 +391,11 @@ STTemplate >> renderOn: anObject [
 STTemplate >> renderOn: anObject partial: partial [
 
 	"Answer the result of rendering the receiver using anObject as template context
-	and the given partial.
+	and the given partial to be yield in the template.
 	The partials are nothing but sub-templates that have also access to the template context.
 	The STTCurrentRenderingContext dynamic variable and STTCurrentRenderingContext gives them
 	access to complete its rendering process."
 
-	self deprecated: 'not used'.
 	^ self
 		  renderOn: anObject
 		  partials: { (#_yield -> partial) } asDictionary

--- a/STTemplate/String.extension.st
+++ b/STTemplate/String.extension.st
@@ -34,21 +34,20 @@ String >> sttRenderOn: anObject [
 ]
 
 { #category : #'*STTemplate' }
-String >> sttRenderOn: anObject partial: partial [
-
+String >> sttRenderOn: anObject partial: aSTTemplate [
 	"Answers the result of rendering an `STTemplate`
 	created from the receiver and rendered using 
-	the given object as template context and the given 
-	partial template to yield within."
+	the given object as context for the template and the given 
+	aSTTemplate to yield within."
 
-	^ self asSTTemplate renderOn: anObject partial: partial
+	^ self asSTTemplate renderOn: anObject partial: aSTTemplate
 ]
 
 { #category : #'*STTemplate' }
-String >> sttRenderOn: anObject partials: partialsDictionarish [
+String >> sttRenderOn: anObject partials: templatesDictionarish [
 
 	"Answers the result of rendering an `STTemplate`
-	 created from the receiver and rendered using the given object."
+	 created from the receiver and rendered using the given object and (sub)templates."
 
-	^ self asSTTemplate renderOn: anObject partials: partialsDictionarish
+	^ self asSTTemplate renderOn: anObject partials: templatesDictionarish
 ]

--- a/tryHtmxBasedCounter.md
+++ b/tryHtmxBasedCounter.md
@@ -48,7 +48,7 @@ sttCounterPage := STTemplate on: '<!DOCTYPE html>
   </head>
   <body>
     <h1>Counter</h1>
-    <h1 id="counterValue"><st= self></h1>
+    <h1 id="counterValue"><%= self%></h1>
     <button
       hx-post="/increase"
       hx-target="#counterValue"
@@ -66,7 +66,7 @@ sttCounterPage := STTemplate on: '<!DOCTYPE html>
 </html>'.
 
 "The one for just the part used to update on increase/decrease"
-sttCounterView := '<h1 id="counterValue"><st= self></h1>' asSTTemplate.
+sttCounterView := '<h1 id="counterValue"><%= self%></h1>' asSTTemplate.
 ```
 
 ### Setup routes

--- a/tryOnTeapot.md
+++ b/tryOnTeapot.md
@@ -29,7 +29,7 @@ teapot	 exception: Error ->  [ :ex :req | | content |
 teapot GET: '/ping' -> 'pong'.
 
 "Create an SSTemplate"
-sstEcho := STTemplate on: '<st [ | echo | echo := self allButFirst ><h1>Echoing:</h1><h2><st= self ></h2><h3><st= echo ></h3><p><st= echo ></p> <st ] value >'.
+sstEcho := STTemplate on: '<% [ | echo | echo := self allButFirst %><h1>Echoing:</h1><h2><%= self %></h2><h3><%= echo %></h3><p><%= echo %></p> <% ] value %>'.
 
 "Add a echo route that will render the HTML the template based on the received message value."
 teapot GET: '/echo/<message>' -> [ :req | sstEcho renderOn: (req at: #message) ].

--- a/tryOnTeapot.md
+++ b/tryOnTeapot.md
@@ -6,7 +6,7 @@ Metacello new
   load.
 ```
 
-### Configure the server and setup routes
+### Configure the server
 ```smalltalk
 "Configure Teapot defaults"
 teapot := Teapot configure: {
@@ -22,7 +22,9 @@ teapot	 exception: Error ->  [ :ex :req | | content |
 		ifFalse: [ 'Internal error' ].
 		TeaResponse serverError body: content.
 	].
-
+```
+### Setup routes
+```smalltalk
 "Add a ping route"
 teapot GET: '/ping' -> 'pong'.
 

--- a/tryOnTeapot.md
+++ b/tryOnTeapot.md
@@ -2,7 +2,7 @@
 ```smalltalk
 Metacello new
   baseline: 'Teapot';
-  repository: 'github://zeroflag/Teapot/source';
+  repository: 'github://zeroflag/Teapot:v2.7.0/source';
   load.
 ```
 


### PR DESCRIPTION
Makes the STT API more consistent with the `render:using:` and `renderUsing:` methods seen in [Ride](https://github.com/sebastianconcept/ride)'s renderer based on STTemplate.

With this change, developers won't need to remember 2 sets of rules for the yield method when used from Ride.

So now this is possible:

```html
<st STT yieldUsing: 'shared/feedback.html' >
<div class="container">
	<h1>Post</h1>
	<st= self render: model>
	<div>
	...
```